### PR TITLE
Параметры выборки

### DIFF
--- a/lib/activity/statistic/ActivityStatisticPreCheckByUser.php
+++ b/lib/activity/statistic/ActivityStatisticPreCheckByUser.php
@@ -90,12 +90,13 @@ class ActivityStatisticPreCheckByUser extends ActivityStatisticPreCheckAbstract 
             );
             $new_entry->save();
 
-            $query = ActivityDealerStaticticStatusTable::getInstance()->createQuery()->where('dealer_id = ? and activity_id = ? and year = ?',
+            $query = ActivityDealerStaticticStatusTable::getInstance()->createQuery()->where('dealer_id = ? and activity_id = ? and year = ? and stat_type = ?',
                 array
                 (
                     $data_to_check->getDealerId(),
                     $activity->getId(),
-                    $data_to_check->getYear()
+                    $data_to_check->getYear(),
+                    Activity::ACTIVITY_STATISTIC_TYPE_SIMPLE
                 )
             );
 
@@ -103,6 +104,7 @@ class ActivityStatisticPreCheckByUser extends ActivityStatisticPreCheckAbstract 
 
             //Фиксируем выполнение статистике в БД
             $item = $query->fetchOne();
+
             if (!$item) {
                 $item = new ActivityDealerStaticticStatus();
                 $item->setArray(


### PR DESCRIPTION
Увеличил количество параметров при выборке из базы данных по статистике, для определения более точного типа статистики (в одной таблице храниться два типа статистик - обычная и расширенная), с учетом того что в одном квартале и году может быть две заполненных статистики (изначально я не расчитывал что такое может быть), бириралась первая заполненная статистика по году и кварталу (без учета типа статистики), в результате чего данные не фиксировались корректно.